### PR TITLE
Use cursor default for frames rows

### DIFF
--- a/data/css/styles.css
+++ b/data/css/styles.css
@@ -59,6 +59,10 @@ code {
   width: 30%;
 }
 
+#content .frameRow {
+  cursor: default;
+}
+
 /******************************************************************************/
 /* Sidebar tabs customization - Firebug Theme */
 


### PR DESCRIPTION
I think that's more elegant to use a default cursor for the frames rows, like below:
![selection_002](https://github-cloud.s3.amazonaws.com/assets/371705/10566301/f25c7c9e-75e3-11e5-8dbd-2bf382d5a3cf.png)

(Currently, the cursor appears as when we hover some text)

Florent
