### PR TITLE
Add ability to filter by socket id

### DIFF
--- a/chrome/locale/en-US/websocket-monitor.properties
+++ b/chrome/locale/en-US/websocket-monitor.properties
@@ -30,6 +30,10 @@ pluralRule=1
 
 websocketmonitor.summary.frameCount=%1$S frame;%1$S frames
 
+# LOCALIZATION NOTE (websocketmonitor.ConnectionFilter.NoFilter): A label displayed
+# to the user inside the connection ID dropdown filter. It shows that the user has
+# not yet selected a connection to filter on, and should inform the user of the
+# purpose of the dropdown.
 websocketmonitor.ConnectionFilter.NoFilter=Filter by Socket ID
 
 # LOCALIZATION NOTE (websocketmonitor.label.sent, websocketmonitor.label.received):

--- a/chrome/locale/en-US/websocket-monitor.properties
+++ b/chrome/locale/en-US/websocket-monitor.properties
@@ -21,6 +21,8 @@ pluralRule=1
 
 websocketmonitor.summary.frameCount=%1$S frame;%1$S frames
 
+websocketmonitor.ConnectionFilter.NoFilter=Filter by connection ID
+
 # LOCALIZATION NOTE (websocketmonitor.label.sent, websocketmonitor.label.received):
 # A label for frames displayed in the frame list.
 websocketmonitor.label.sent=Sent

--- a/chrome/locale/en-US/websocket-monitor.properties
+++ b/chrome/locale/en-US/websocket-monitor.properties
@@ -21,7 +21,7 @@ pluralRule=1
 
 websocketmonitor.summary.frameCount=%1$S frame;%1$S frames
 
-websocketmonitor.ConnectionFilter.NoFilter=Filter by connection ID
+websocketmonitor.ConnectionFilter.NoFilter=Filter by Socket ID
 
 # LOCALIZATION NOTE (websocketmonitor.label.sent, websocketmonitor.label.received):
 # A label for frames displayed in the frame list.

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -1,0 +1,60 @@
+/* See license.txt for terms of usage */
+
+define(function(require, exports/*, module*/) {
+
+"use strict";
+
+// Dependencies
+const React = require("react");
+
+// WebSockets Monitor
+const { filterFrames } = require("../actions/frames");
+
+// Shortcuts
+const { span, select, option } = React.DOM;
+
+/**
+ * TODO
+ */
+var ConnectionFilter = React.createClass({
+/** @lends ConnectionFilter */
+
+  displayName: "ConnectionFilter",
+
+  handleChange: function(e) {
+    const { value } = e.target;
+    const currentFilter = this.props.frames.filter;
+
+    this.props.dispatch(filterFrames(
+      Object.assign({}, currentFilter, {
+        webSocketSerialID: Number(value)
+      })
+    ));
+  },
+
+  render: function() {
+
+    var uniqueConnections = [];
+    this.props.frames.frames.forEach(function(frame) {
+      if (!uniqueConnections.includes(frame.webSocketSerialID)) {
+        uniqueConnections.push(frame.webSocketSerialID);
+      }
+    });
+
+    return (
+      uniqueConnections.length > 1 ?
+        select({ onChange: this.handleChange },
+          option(Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
+          uniqueConnections.map(function(id, i) {
+            return option({key: i, value: id}, id);
+          })
+        ) :
+        span()
+    );
+  }
+});
+
+// Exports from this module
+exports.ConnectionFilter = ConnectionFilter;
+});
+

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -25,6 +25,12 @@ var ConnectionFilter = React.createClass({
 
   displayName: "ConnectionFilter",
 
+  getInitialState() {
+    return {
+      uniqueConnections: []
+    };
+  },
+
   handleChange(e) {
     const { value } = e.target;
     const currentFilter = this.props.frames.filter;
@@ -38,18 +44,31 @@ var ConnectionFilter = React.createClass({
     ));
   },
 
-  render() {
-    const uniqueConnections = [];
-    this.props.frames.frames.forEach(frame => {
-      if (!uniqueConnections.includes(frame.webSocketSerialID)) {
-        uniqueConnections.push(frame.webSocketSerialID);
-      }
-    });
+  // When the platform API supports it, this should be replaced
+  // with some API call listing only the current connections on
+  // the page.
+  componentWillReceiveProps({ frames }) {
+    if (frames && Array.isArray(frames.frames)) {
+      frames.frames.forEach(frame => {
+        const { uniqueConnections } = this.state;
+        if (!uniqueConnections.includes(frame.webSocketSerialID)) {
+          this.setState({
+            uniqueConnections: [...uniqueConnections, frame.webSocketSerialID]
+          });
+        }
+      })
+    }
+  },
 
+  render() {
+    const { uniqueConnections } = this.state;
     return (
       uniqueConnections.length > 1 ?
-        select({ className: "ConnectionFilter", onChange: this.handleChange },
-          option({ value: null }, Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
+        select({
+          className: "ConnectionFilter",
+          value: this.props.frames.filter.webSocketSerialID,
+          onChange: this.handleChange
+        }, option({ value: null }, Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
           uniqueConnections.map((id, i) => {
             return option({key: i, value: id}, id);
           })

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -33,7 +33,7 @@ var ConnectionFilter = React.createClass({
     // retain text filter alongside this filter.
     this.props.dispatch(filterFrames(
       Object.assign({}, currentFilter, {
-        webSocketSerialID: value ? Number(value) : null
+        webSocketSerialID: value !== null ? Number(value) : null
       })
     ));
   },

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -39,7 +39,6 @@ var ConnectionFilter = React.createClass({
   },
 
   render: function() {
-
     var uniqueConnections = [];
     this.props.frames.frames.forEach(frame => {
       if (!uniqueConnections.includes(frame.webSocketSerialID)) {
@@ -49,7 +48,7 @@ var ConnectionFilter = React.createClass({
 
     return (
       uniqueConnections.length > 1 ?
-        select({ className: 'ConnectionFilter', onChange: this.handleChange },
+        select({ className: "ConnectionFilter", onChange: this.handleChange },
           option({ value: null }, Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
           uniqueConnections.map((id, i) => {
             return option({key: i, value: id}, id);

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -43,8 +43,8 @@ var ConnectionFilter = React.createClass({
 
     return (
       uniqueConnections.length > 1 ?
-        select({ onChange: this.handleChange },
-          option(Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
+        select({ className: 'ConnectionFilter', onChange: this.handleChange },
+          option({ value: null }, Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
           uniqueConnections.map(function(id, i) {
             return option({key: i, value: id}, id);
           })

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -48,16 +48,15 @@ var ConnectionFilter = React.createClass({
   // with some API call listing only the current connections on
   // the page.
   componentWillReceiveProps({ frames }) {
-    if (frames && Array.isArray(frames.frames)) {
-      frames.frames.forEach(frame => {
-        const { uniqueConnections } = this.state;
-        if (!uniqueConnections.includes(frame.webSocketSerialID)) {
-          this.setState({
-            uniqueConnections: [...uniqueConnections, frame.webSocketSerialID]
-          });
-        }
-      })
-    }
+    frames.frames.forEach(frame => {
+      const { uniqueConnections } = this.state;
+
+      if (!uniqueConnections.includes(frame.webSocketSerialID)) {
+        this.setState({
+          uniqueConnections: [...uniqueConnections, frame.webSocketSerialID]
+        });
+      }
+    })
   },
 
   render() {

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -33,7 +33,7 @@ var ConnectionFilter = React.createClass({
     // retain text filter alongside this filter.
     this.props.dispatch(filterFrames(
       Object.assign({}, currentFilter, {
-        webSocketSerialID: Number(value)
+        webSocketSerialID: value ? Number(value) : null
       })
     ));
   },

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -25,7 +25,7 @@ var ConnectionFilter = React.createClass({
 
   displayName: "ConnectionFilter",
 
-  handleChange: function(e) {
+  handleChange(e) {
     const { value } = e.target;
     const currentFilter = this.props.frames.filter;
 
@@ -38,8 +38,8 @@ var ConnectionFilter = React.createClass({
     ));
   },
 
-  render: function() {
-    var uniqueConnections = [];
+  render() {
+    const uniqueConnections = [];
     this.props.frames.frames.forEach(frame => {
       if (!uniqueConnections.includes(frame.webSocketSerialID)) {
         uniqueConnections.push(frame.webSocketSerialID);

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -14,7 +14,11 @@ const { filterFrames } = require("../actions/frames");
 const { span, select, option } = React.DOM;
 
 /**
- * TODO
+ * This component renders a select element when unique
+ * webSocket connections > 1. Using this dropdown, the
+ * user can select the connection ID they are interested
+ * in seeing, and a reducer should filter out all other
+ * connections.
  */
 var ConnectionFilter = React.createClass({
 /** @lends ConnectionFilter */
@@ -25,6 +29,8 @@ var ConnectionFilter = React.createClass({
     const { value } = e.target;
     const currentFilter = this.props.frames.filter;
 
+    // Dispatch new filter, merging with old filter to
+    // retain text filter alongside this filter.
     this.props.dispatch(filterFrames(
       Object.assign({}, currentFilter, {
         webSocketSerialID: Number(value)
@@ -35,7 +41,7 @@ var ConnectionFilter = React.createClass({
   render: function() {
 
     var uniqueConnections = [];
-    this.props.frames.frames.forEach(function(frame) {
+    this.props.frames.frames.forEach(frame => {
       if (!uniqueConnections.includes(frame.webSocketSerialID)) {
         uniqueConnections.push(frame.webSocketSerialID);
       }
@@ -45,10 +51,11 @@ var ConnectionFilter = React.createClass({
       uniqueConnections.length > 1 ?
         select({ className: 'ConnectionFilter', onChange: this.handleChange },
           option({ value: null }, Locale.$STR("websocketmonitor.ConnectionFilter.NoFilter")),
-          uniqueConnections.map(function(id, i) {
+          uniqueConnections.map((id, i) => {
             return option({key: i, value: id}, id);
           })
         ) :
+        // else, no-op
         span()
     );
   }

--- a/data/components/main-toolbar.js
+++ b/data/components/main-toolbar.js
@@ -14,6 +14,7 @@ const { Toolbar, ToolbarButton } = createFactories(require("reps/toolbar"));
 // WebSockets Monitor
 const { clear } = require("../actions/frames");
 const { SearchBox } = require("./search-box");
+const { ConnectionFilter } = createFactories(require("./connection-filter"));
 
 /**
  * @template This object is responsible for rendering the toolbar
@@ -88,7 +89,8 @@ var MainToolbar = React.createClass({
         ),
         ToolbarButton({bsSize: "xsmall", onClick: this.onSwitchPerspective},
           perspectiveLabel
-        )
+        ),
+        ConnectionFilter(this.props)
       )
     );
   },

--- a/data/components/main-toolbar.js
+++ b/data/components/main-toolbar.js
@@ -13,7 +13,7 @@ const { Toolbar, ToolbarButton } = createFactories(require("reps/toolbar"));
 
 // WebSockets Monitor
 const { clear } = require("../actions/frames");
-const { SearchBox } = require("./search-box");
+const { SearchBox } = createFactories(require("./search-box"));
 const { ConnectionFilter } = createFactories(require("./connection-filter"));
 
 /**
@@ -29,16 +29,6 @@ var MainToolbar = React.createClass({
     return {
       paused: false
     }
-  },
-
-  componentDidMount: function() {
-    var toolbar = this.refs.toolbar.getDOMNode();
-    SearchBox.create(toolbar);
-  },
-
-  componentWillUnmount: function() {
-    var toolbar = this.refs.toolbar.getDOMNode();
-    SearchBox.destroy(toolbar);
   },
 
   // Commands
@@ -90,6 +80,7 @@ var MainToolbar = React.createClass({
         ToolbarButton({bsSize: "xsmall", onClick: this.onSwitchPerspective},
           perspectiveLabel
         ),
+        SearchBox(this.props),
         ConnectionFilter(this.props)
       )
     );

--- a/data/components/search-box.js
+++ b/data/components/search-box.js
@@ -24,21 +24,25 @@ var SearchBox = React.createClass({
 
   displayName: "SearchBox",
 
-  componentWillMount() {
-    this.setState({ win: document.defaultView },
-                  () => this.state.win.addEventListener("theme-changed", this.handleThemeChange));
+  getInitialState() {
+    return {
+      text: ""
+    };
+  },
+
+  componentDidMount() {
+    document.defaultView.addEventListener("theme-changed", this.handleThemeChange);
   },
 
   componentWillUnmount() {
-    this.state.win.removeEventListener("theme-changed", this.handleThemeChange);
+    document.defaultView.removeEventListener("theme-changed", this.handleThemeChange);
   },
 
-  handleThemeChange(searchBox, event) {
+  handleThemeChange(event) {
     const data = event.data;
 
     // Reset the filter if Firebug theme has been activated or deactivated.
     if (data.newTheme == "firebug" || data.oldTheme == "firebug") {
-      searchBox.value = "";
       this.onChange("");
     }
   },
@@ -51,18 +55,17 @@ var SearchBox = React.createClass({
     this.props.dispatch(filterFrames(
       Object.assign({}, currentFilter, { text })
     ));
+    this.setState({ text });
   },
 
   render() {
-    const searchBox = input({
+    return input({
       className: "devtools-searchinput",
       type: "search",
       results: "true",
+      value: this.state.text,
       onChange: e => this.onChange(e.target.value)
     });
-
-    this.handleThemeChange = this.handleThemeChange.bind(this, searchBox);
-    return searchBox;
   }
 });
 

--- a/data/components/search-box.js
+++ b/data/components/search-box.js
@@ -4,77 +4,67 @@ define(function(require, exports/*, module*/) {
 
 "use strict";
 
+// Dependencies
+const React = require("react");
+
+// WebSockets Monitor
+const { filterFrames } = require("../actions/frames");
+
+// Shortcuts
+const { input } = React.DOM;
+
 /**
- * TODO docs xxxHonza: use ReactJS.
+ * This component renders a search box that allows the
+ * user to filter on the content of the frames in the
+ * list. It dispatches a "filterFrames" event with the
+ * updated text filter.
  */
-var SearchBox =
+var SearchBox = React.createClass({
 /** @lends SearchBox */
-{
-  create: function(parentNode) {
-    var doc = parentNode.ownerDocument;
-    var win = doc.defaultView;
-    var toolbar = doc.querySelector(".mainPanel .toolbar");
 
-    // Search box
-    var searchBox = doc.createElement("input");
-    searchBox.setAttribute("class", "devtools-searchinput");
-    searchBox.setAttribute("type", "search");
-    searchBox.setAttribute("results", "true");
-    toolbar.appendChild(searchBox);
+  displayName: "SearchBox",
 
-    searchBox.addEventListener("command", this.onChange.bind(this, searchBox), false);
-    searchBox.addEventListener("input", this.onChange.bind(this, searchBox), false);
-    searchBox.addEventListener("keypress", this.onKeyPress.bind(this, searchBox), false);
-
-    this.handleThemeChange = this.handleThemeChange.bind(this, searchBox);
-    win.addEventListener("theme-changed", this.handleThemeChange);
+  componentWillMount() {
+    this.setState({ win: document.defaultView },
+                  () => this.state.win.addEventListener("theme-changed", this.handleThemeChange));
   },
 
-  destroy: function(parentNode) {
-    var doc = parentNode.ownerDocument;
-    var searchBox = doc.querySelector(".searchBox");
-    searchBox.remove();
-    win.removeEventListener("theme-changed", this.handleThemeChange);
+  componentWillUnmount() {
+    this.state.win.removeEventListener("theme-changed", this.handleThemeChange);
   },
 
-  handleThemeChange: function(searchBox, event) {
-    var data = event.data;
-    var win = searchBox.ownerDocument.defaultView;
+  handleThemeChange(searchBox, event) {
+    const data = event.data;
 
     // Reset the filter if Firebug theme has been activated or deactivated.
     if (data.newTheme == "firebug" || data.oldTheme == "firebug") {
       searchBox.value = "";
-      this.dispatch(win, {
-        text: ""
-      });
+      this.onChange("");
     }
   },
 
-  onKeyPress: function(searchBox/*, event*/) {
-    this.onSearch(searchBox);
+  onChange(text) {
+    const currentFilter = this.props.frames.filter;
+
+    // Dispatch new filter, merging with old filter to
+    // retain connectionId filter alongside this filter.
+    this.props.dispatch(filterFrames(
+      Object.assign({}, currentFilter, { text })
+    ));
   },
 
-  onChange: function(searchBox/*, event*/) {
-    this.onSearch(searchBox);
-  },
-
-  onSearch: function(searchBox) {
-    var win = searchBox.ownerDocument.defaultView;
-    this.dispatch(win, {
-      text: searchBox.value
+  render() {
+    const searchBox = input({
+      className: "devtools-searchinput",
+      type: "search",
+      results: "true",
+      onChange: e => this.onChange(e.target.value)
     });
-  },
 
-  dispatch: function(win, filter) {
-    var event = new win.MessageEvent("firebug.sdk/chrome-event", {
-      data: {
-        method: "onSearch",
-        args: filter
-      }
-    });
-    win.dispatchEvent(event);
+    this.handleThemeChange = this.handleThemeChange.bind(this, searchBox);
+    return searchBox;
   }
-};
+});
 
 // Exports from this module
 exports.SearchBox = SearchBox;

--- a/data/css/connection-filter.css
+++ b/data/css/connection-filter.css
@@ -1,0 +1,16 @@
+/* See license.txt for terms of usage */
+
+/******************************************************************************/
+/* Connection Filter Dropdown */
+
+.ConnectionFilter {
+  float: right;
+  height: 22px;
+  border: 1px solid rgb(204, 204, 204);
+  font-size: 14px;
+
+  background: rgb(255, 255, 255) none repeat scroll 0% 0%;
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+  color: rgb(85, 85, 85);
+}
+

--- a/data/css/connection-filter.css
+++ b/data/css/connection-filter.css
@@ -9,11 +9,15 @@
   background: rgba(170, 170, 170, .3);
 }
 
+.theme-firebug .ConnectionFilter {
+  color: #333;
+  border-radius: 2px;
+}
+
 .ConnectionFilter {
   float: right;
   height: 22px;
   border: 1px solid rgb(204, 204, 204);
-  font-size: 14px;
 
   background: rgb(255, 255, 255) none repeat scroll 0% 0%;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;

--- a/data/css/connection-filter.css
+++ b/data/css/connection-filter.css
@@ -3,6 +3,12 @@
 /******************************************************************************/
 /* Connection Filter Dropdown */
 
+.theme-dark .ConnectionFilter {
+  color: var(--theme-content-color1);
+  border: none;
+  background: rgba(170, 170, 170, .3);
+}
+
 .ConnectionFilter {
   float: right;
   height: 22px;

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -112,7 +112,9 @@ function filterFrames(state, filter) {
 
     frames = frames.filter(frame => {
       var data = frame.data;
-      if (data.payload && data.payload.indexOf(filter.text) != -1) {
+
+      // Exclude where data is null (events). Events have no payload
+      if (data && data.payload && data.payload.indexOf(filter.text) != -1) {
         summary.totalSize += data.payload.length;
         summary.startTime = summary.startTime ? summary.startTime : data.timeStamp;
         summary.endTime = data.timeStamp;
@@ -133,10 +135,16 @@ function filterFrames(state, filter) {
     frames = frames.filter(frame => {
       var data = frame.data;
       if (frame.webSocketSerialID === filter.webSocketSerialID) {
-        summary.totalSize += data.payload.length;
-        summary.startTime = summary.startTime ? summary.startTime : data.timeStamp;
-        summary.endTime = data.timeStamp;
-        summary.frameCount++;
+
+        // If data is null, this is not an actual frame, but an event
+        // like "connect" or "disconnect". We still want to keep it
+        // in the list, though.
+        if (data) {
+          summary.totalSize += data.payload.length;
+          summary.startTime = summary.startTime ? summary.startTime : data.timeStamp;
+          summary.endTime = data.timeStamp;
+          summary.frameCount++;
+        }
         return true;
       }
     });
@@ -153,10 +161,9 @@ function filterFrames(state, filter) {
 }
 
 function clear(state) {
-  // All data are cleared except of the current filter.
+  // All data are cleared except of the current text filter.
   var newState = getInitialState();
   newState.filter.text = state.filter.text;
-  newState.filter.webSocketSerialID = state.filter.webSocketSerialID;
   return newState;
 }
 

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -90,11 +90,7 @@ function addFrames(state, newFrames) {
   });
 
   // Apply filter on incoming frames.
-  if (newState.filter.text || newState.filter.webSocketSerialID) {
-    return filterFrames(newState, newState.filter);
-  }
-
-  return newState;
+  return filterFrames(newState, newState.filter);
 }
 
 function filterFrames(state, filter) {

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -161,9 +161,10 @@ function filterFrames(state, filter) {
 }
 
 function clear(state) {
-  // All data are cleared except of the current text filter.
+  // All data is cleared except for the current filters.
   var newState = getInitialState();
   newState.filter.text = state.filter.text;
+  newState.filter.webSocketSerialID = state.filter.webSocketSerialID;
   return newState;
 }
 

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -98,7 +98,7 @@ function addFrames(state, newFrames) {
 }
 
 function filterFrames(state, filter) {
-  var frames;
+  var { frames } = state;
 
   var summary = {
     totalSize: 0,
@@ -108,7 +108,7 @@ function filterFrames(state, filter) {
   };
 
   if (filter.text) {
-    frames = state.frames.filter(frame => {
+    frames = frames.filter(frame => {
       var data = frame.data;
       if (data.payload.indexOf(filter.text) != -1) {
         summary.totalSize += data.payload.length;
@@ -118,7 +118,30 @@ function filterFrames(state, filter) {
         return true;
       }
     });
-  } else {
+  }
+
+  if (filter.webSocketSerialID) {
+    // Reset in case it was set in above filter
+    summary = {
+      totalSize: 0,
+      startTime: 0,
+      endTime: 0,
+      frameCount: 0
+    };
+
+    frames = frames.filter(frame => {
+      var data = frame.data;
+      if (frame.webSocketSerialID === filter.webSocketSerialID) {
+        summary.totalSize += data.payload.length;
+        summary.startTime = summary.startTime ? summary.startTime : data.timeStamp;
+        summary.endTime = data.timeStamp;
+        summary.frameCount++;
+        return true;
+      }
+    });
+  }
+
+  if (!filter.text && !filter.connectionId) {
     summary = null;
   }
 

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -99,15 +99,16 @@ function addFrames(state, newFrames) {
 
 function filterFrames(state, filter) {
   var { frames } = state;
-
-  var summary = {
-    totalSize: 0,
-    startTime: 0,
-    endTime: 0,
-    frameCount: 0
-  };
+  var summary = null;
 
   if (filter.text) {
+    summary = {
+      totalSize: 0,
+      startTime: 0,
+      endTime: 0,
+      frameCount: 0
+    };
+
     frames = frames.filter(frame => {
       var data = frame.data;
       if (data.payload.indexOf(filter.text) != -1) {
@@ -121,7 +122,6 @@ function filterFrames(state, filter) {
   }
 
   if (filter.webSocketSerialID) {
-    // Reset in case it was set in above filter
     summary = {
       totalSize: 0,
       startTime: 0,
@@ -141,13 +141,10 @@ function filterFrames(state, filter) {
     });
   }
 
-  if (!filter.text && !filter.connectionId) {
-    summary = null;
-  }
-
   return Object.assign({}, state, {
     filter: {
       text: filter.text,
+      webSocketSerialID: filter.webSocketSerialID,
       frames: frames,
       summary: summary,
     }
@@ -158,6 +155,7 @@ function clear(state) {
   // All data are cleared except of the current filter.
   var newState = getInitialState();
   newState.filter.text = state.filter.text;
+  newState.filter.webSocketSerialID = state.filter.webSocketSerialID;
   return newState;
 }
 

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -90,7 +90,7 @@ function addFrames(state, newFrames) {
   });
 
   // Apply filter on incoming frames.
-  if (newState.filter.text) {
+  if (newState.filter.text || newState.filter.webSocketSerialID) {
     return filterFrames(newState, newState.filter);
   }
 

--- a/data/view.html
+++ b/data/view.html
@@ -9,6 +9,7 @@
   <link href="./css/styles.css" rel="stylesheet">
   <link href="./css/frame-table.css" rel="stylesheet">
   <link href="./css/frame-list.css" rel="stylesheet">
+  <link href="./css/connection-filter.css" rel="stylesheet">
   <link href="./css/search-box.css" rel="stylesheet">
   <link href="./css/no-service-warning.css" rel="stylesheet">
   <script src="../node_modules/keymaster/keymaster.js"></script>


### PR DESCRIPTION
Figured I might as well start helping out :)

This PR adds a dropdown to main-toolbar which allows the user to filter the list of frames based on the connection ID of that frame. It is only visible when there is more than one active connection.

I read issue #30, and agree with @fflorent - I believe this is a better solution than using a `#` prefix. This is because it is immediately apparent to the user how to filter on ID, and there is no need to teach the user how to do so.

Fixes #30

![screenshot from 2015-11-22 01-10-51](https://cloud.githubusercontent.com/assets/5845924/11321215/831f0cd2-90b6-11e5-8e1c-f5208dbfe448.png)
