### PR TITLE
Clear connection ID filter list on reload

### DIFF
--- a/data/actions/frames.js
+++ b/data/actions/frames.js
@@ -11,8 +11,8 @@ const types = {
   FILTER_FRAMES: "FILTER_FRAMES",
 }
 
-function clear() {
-  return { type: types.CLEAR };
+function clear(options) {
+  return { type: types.CLEAR, options };
 }
 
 function addFrame(frame) {

--- a/data/components/connection-filter.js
+++ b/data/components/connection-filter.js
@@ -25,12 +25,6 @@ var ConnectionFilter = React.createClass({
 
   displayName: "ConnectionFilter",
 
-  getInitialState() {
-    return {
-      uniqueConnections: []
-    };
-  },
-
   handleChange(e) {
     const { value } = e.target;
     const currentFilter = this.props.frames.filter;
@@ -44,23 +38,8 @@ var ConnectionFilter = React.createClass({
     ));
   },
 
-  // When the platform API supports it, this should be replaced
-  // with some API call listing only the current connections on
-  // the page.
-  componentWillReceiveProps({ frames }) {
-    frames.frames.forEach(frame => {
-      const { uniqueConnections } = this.state;
-
-      if (!uniqueConnections.includes(frame.webSocketSerialID)) {
-        this.setState({
-          uniqueConnections: [...uniqueConnections, frame.webSocketSerialID]
-        });
-      }
-    })
-  },
-
   render() {
-    const { uniqueConnections } = this.state;
+    const { uniqueConnections } = this.props.frames;
     return (
       uniqueConnections.length > 1 ?
         select({

--- a/data/reducers/frames.js
+++ b/data/reducers/frames.js
@@ -180,6 +180,7 @@ function clear(state, options = {}) {
   // Allow clearing on page reload
   if (options.resetIDfilter !== true) {
     newState.filter.webSocketSerialID = state.filter.webSocketSerialID;
+    newState.uniqueConnections = state.uniqueConnections;
   }
 
   return newState;

--- a/data/view.js
+++ b/data/view.js
@@ -60,8 +60,9 @@ var WebSocketsView = createView(PanelView,
 
   // Chrome Messages
 
-  removeFrames: function() {
-    store.dispatch(clear());
+  tabNavigated: function() {
+    // Clear on reload, and force ID filter reset
+    store.dispatch(clear({ resetIDfilter: true }));
   },
 
   // nsIWebSocketEventService events

--- a/lib/wsm-panel.js
+++ b/lib/wsm-panel.js
@@ -183,7 +183,7 @@ const WsmPanel = Class(
   },
 
   onTabNavigated: function() {
-    this.postContentMessage("removeFrames");
+    this.postContentMessage("tabNavigated");
   },
 
   // nsIWebSocketEventService events


### PR DESCRIPTION
- Moves state of connection ID filter to redux store
  - This automatically clears the list on reload, as it returns to initialState on clear
  - Persist list on clears using custom clear event with `resetIDfilter` option. This is like prevous implementation in #34 
- Rename `removeFrames` event -> `tabNavigated`

Fixes #41 
