### PR TITLE
Fix encoding issues, closes #39, closes #43

### DIFF
--- a/data/view.js
+++ b/data/view.js
@@ -86,7 +86,7 @@ var WebSocketsView = createView(PanelView,
    * about the mapping event -> method.
    */
   frameReceived: function(frame) {
-    frame = JSON.parse(frame);
+    frame = JSON.parse(decodeURIComponent(escape(frame)));
     frame.received = true;
     frame.type = "frame";
     frame.data.webSocketSerialID = frame.webSocketSerialID;
@@ -95,7 +95,7 @@ var WebSocketsView = createView(PanelView,
   },
 
   frameSent: function(frame) {
-    frame = JSON.parse(frame);
+    frame = JSON.parse(decodeURIComponent(escape(frame)));
     frame.sent = true;
     frame.type = "frame";
     frame.data.webSocketSerialID = frame.webSocketSerialID;


### PR DESCRIPTION
Hi there! I've managed to fix encoding issues. My steps of this issue investigation:
1. Using online decoders, I've tried to decode messed up payload and learned that for whatever reason `frame`'s payload was in `ISO-8859-1` encoding.
2. I've found the way to convert `ISO-8859-1` to `UTF-8` in [here on StackOverflow](http://stackoverflow.com/a/22594794/2300710), using "the other way round".
3. I added the corresponding reencoding code to `frameReceived` and `frameSend`, the only 2 places where a `frame` gets `JSON.parse`d.

Look at the results (using your [WebSockets test page](http://janodvarko.cz/test/websockets/)):
With turkish symbols:
![](https://i.imgur.com/ksvXw75.png)

With cyrillic symbols:
![](https://i.imgur.com/YVn9Gj7.png)

This should close issues #39, #43.
