### PR TITLE
Fix net panel layout and colour on dark theme

### DIFF
--- a/chrome/content/network-content-script.js
+++ b/chrome/content/network-content-script.js
@@ -23,8 +23,15 @@ window.on(EVENTS.RECEIVED_REQUEST_HEADERS, (event, from) => {
 
   // Append WebSocket icon in the UI
   var hbox = item._target;
-  var status = hbox.querySelector(".requests-menu-status");
-  status.classList.add("websocket");
+  var statusIconNode = hbox.querySelector(".requests-menu-status-icon");
+
+  // FF 45 changed the DOM layout in the network panel,
+  // so we fall back to old selector if no match with
+  // this one
+  if (!statusIconNode) {
+    statusIconNode = hbox.querySelector(".requests-menu-status");
+  }
+  statusIconNode.classList.add("websocket");
 
   // Register click handler and emit an event that is handled
   // in the 'WsmNetMonitorOverlay' overlay.

--- a/chrome/skin/classic/netmonitor.css
+++ b/chrome/skin/classic/netmonitor.css
@@ -4,6 +4,9 @@
 /* Network Panel */
 
 /* Web Socket Icon */
+/* FF 45 changed the DOM layout, so we fallback to using
+ * old .requests-menu-status in network-content-script.js */
+.requests-menu-status-icon.websocket,
 .requests-menu-status.websocket {
   background-image: url("./tool-websockets.svg");
   background-repeat: no-repeat;

--- a/chrome/skin/classic/netmonitor.css
+++ b/chrome/skin/classic/netmonitor.css
@@ -24,6 +24,12 @@
   filter: url(./filters.svg#invert);
 }
 
+/* Clear filter on icon for dark theme so it is white */
+.theme-dark .requests-menu-status-icon.websocket,
+.theme-dark .requests-menu-status.websocket {
+  filter: initial;
+}
+
 .theme-firebug box.requests-menu-status.websocket {
   background-color: transparent !important;
 }


### PR DESCRIPTION
Welcome back, honza

I saw you published some bugs on the issue tracker, and I figured I might lend a hand at squashing them.

This PR fixes the layout issues in the network panel, and also adresses some colour issues with the dark theme (colours were black-on-black). The reason the net panel broke, was because the dom nodes seem to have changed in FF 45. I added a fallback for FF 44 where we use the older css selector.

![screenshot_20160216_215543](https://cloud.githubusercontent.com/assets/5845924/13090785/1b8c2592-d4f8-11e5-8ab1-8083562be5e3.png)
![screenshot_20160216_215601](https://cloud.githubusercontent.com/assets/5845924/13090787/1c8d540c-d4f8-11e5-90ab-c99b11f6d5f7.png)

closes #45 
