### PR TITLE
Add inline previews for table view

### DIFF
--- a/data/components/frame-table.js
+++ b/data/components/frame-table.js
@@ -120,6 +120,32 @@ var FrameRow = React.createFactory(React.createClass({
 
   displayName: "FrameRow",
 
+  getInitialState() {
+    return {};
+  },
+
+  /**
+   * Create TreeView sub-components in lifecycle methods so we
+   * only generate them once and don't run into state issues
+   * with the TreeView component.
+   */
+  componentWillMount() {
+    if (this.props.frame) {
+      this.setState({ payload: this.buildPayload(this.props.frame) });
+    }
+  },
+
+  /**
+   * Create TreeView sub-components in lifecycle methods so we
+   * only generate them once and don't run into state issues
+   * with the TreeView component.
+   */
+  componentWillReceiveProps({ frame }) {
+    if (frame !== this.props.frame) {
+      this.setState({ payload: this.buildPayload(this.props.frame) });
+    }
+  },
+
   /**
    * Frames need to be re-rendered only if the selection changes.
    * This is an optimization that makes the list rendering a lot faster.
@@ -136,22 +162,8 @@ var FrameRow = React.createFactory(React.createClass({
     }
   },
 
-  render: function() {
-    var frame = this.props.frame;
-    var data = frame.data;
-
-    var className = "frameRow " + (frame.sent ? "send" : "receive");
-    var tooltipText = frame.sent ? "Sent" : "Received";
-
-    if (this.props.selection == frame) {
-      className += " selected";
-    }
-
+  buildPayload(frame) {
     var payload;
-    var size =  Str.formatSize(data.payload.length);
-    var time = new Date(data.timeStamp / 1000);
-    var timeText = time.getHours() + ":" + time.getMinutes() +
-      ":" + time.getSeconds() + "." + time.getMilliseconds();
 
     // Test support for inline previews.
     if (frame.socketIo) {
@@ -171,8 +183,27 @@ var FrameRow = React.createFactory(React.createClass({
       });
     } else {
       // Fall back to showing a string
-      payload = Str.cropString(data.payload, 50);
+      payload = Str.cropString(frame.data.payload, 50);
     }
+    return payload;
+  },
+
+  render: function() {
+    var frame = this.props.frame;
+    var payload = this.state.payload;
+    var data = frame.data;
+
+    var className = "frameRow " + (frame.sent ? "send" : "receive");
+    var tooltipText = frame.sent ? "Sent" : "Received";
+
+    if (this.props.selection == frame) {
+      className += " selected";
+    }
+
+    var size =  Str.formatSize(data.payload.length);
+    var time = new Date(data.timeStamp / 1000);
+    var timeText = time.getHours() + ":" + time.getMinutes() +
+      ":" + time.getSeconds() + "." + time.getMilliseconds();
 
     return (
       tr({className: className, onClick: this.onClick},

--- a/data/components/frame-table.js
+++ b/data/components/frame-table.js
@@ -125,8 +125,9 @@ var FrameRow = React.createFactory(React.createClass({
    * This is an optimization that makes the list rendering a lot faster.
    */
   shouldComponentUpdate: function(nextProps, nextState) {
-    return this.props.frame == nextProps.selection ||
-      this.props.frame == this.props.selection;
+    return nextProps.selection !== this.props.selection && (
+      this.props.frame == nextProps.selection ||
+      this.props.frame == this.props.selection);
   },
 
   onClick: function() {
@@ -146,18 +147,32 @@ var FrameRow = React.createFactory(React.createClass({
       className += " selected";
     }
 
-    var payload = Str.cropString(data.payload, 50);
-    var size = Str.formatSize(data.payload.length);
+    var payload;
+    var size =  Str.formatSize(data.payload.length);
     var time = new Date(data.timeStamp / 1000);
     var timeText = time.getHours() + ":" + time.getMinutes() +
       ":" + time.getSeconds() + "." + time.getMilliseconds();
 
-    // Test support for inline previews. The problem is the
-    // state of the TreeView component.
-    /*if (frame.socketIo) {
-      var data = { payload: frame.socketIo };
-      payload = TreeView({key: "detailsTabTree", data: data})
-    }*/
+    // Test support for inline previews.
+    if (frame.socketIo) {
+      payload = TreeView({
+        key: "preview-socketio",
+        data: {"Socket IO": frame.socketIo},
+      });
+    } else if (frame.sockJs) {
+      payload = TreeView({
+        key: "preview-sockjs",
+        data: {"SockJS": frame.sockJs},
+      });
+    } else if (frame.json) {
+      payload = TreeView({
+        key: "preview-json",
+        data: {"JSON": frame.json},
+      });
+    } else {
+      // Fall back to showing a string
+      payload = Str.cropString(data.payload, 50);
+    }
 
     return (
       tr({className: className, onClick: this.onClick},

--- a/data/css/frame-table.css
+++ b/data/css/frame-table.css
@@ -61,6 +61,27 @@
 }
 
 /******************************************************************************/
+/* Inline Packet Details Preview */
+
+.frameRow .preview {
+  overflow: auto;
+  width: 100%;
+  max-height: 200px;
+}
+
+.frameRow .memberRow:hover {
+  background-color: transparent;
+}
+
+.frameRow .domTable {
+  width: auto;
+}
+
+.frameRow .domTable > tbody > tr > td {
+  border-bottom: transparent;
+}
+
+/******************************************************************************/
 /* Events */
 
 .eventRow .uri {
@@ -149,21 +170,6 @@
 }
 
 /******************************************************************************/
-/* Frame Row Selection */
-
-.frameRow:not(.selected):hover td {
-  background: #EFEFEF;
-}
-
-.eventRow.selected .text,
-.eventRow.selected .uri,
-.frameRow.selected td.opcode,
-.frameRow.selected td {
-  background: #3399ff;
-  color: white;
-}
-
-/******************************************************************************/
 /* Summary */
 
 .frameTFoot td {
@@ -206,15 +212,15 @@
   border-bottom: none;
 }
 
-.theme-light .frameRow:hover td,
-.theme-dark .frameRow:hover td {
-  background-color: var(--theme-selection-background-semitransparent);
+.theme-light .frameRow:hover>td,
+.theme-dark .frameRow:hover>td {
+  background-color: var(--theme-toolbar-background);
 }
 
-.theme-light .frameRow.selected td,
-.theme-dark .frameRow.selected td {
-  color: var(--theme-selection-color);
-  background-color: var(--theme-selection-background);
+.theme-light .frameRow.selected>td,
+.theme-dark .frameRow.selected>td {
+  /* JSON text (blue) must be visible, so we can't use --theme-selection-background */
+  background-color: var(--theme-selection-background-semitransparent);
 }
 
 .theme-light .frameTHead th,


### PR DESCRIPTION
Hi again, @janodvarko.

I completed your feature for inline preview of trees in the table view. Have a look, tell me what you think.

I had to change a few colours to make it look good. With the "selected" before I started, the text was not readable because it was blue-on-blue, which is no good. I added screenshots of the new look below.

![screenshot_20160219_221131](https://cloud.githubusercontent.com/assets/5845924/13189404/74e02394-d757-11e5-91cf-9665724ba200.png)
![screenshot_20160219_221147](https://cloud.githubusercontent.com/assets/5845924/13189405/74e0ff80-d757-11e5-9004-26a404df7395.png)

closes #5 
