### PR TITLE
Socket.IO: Show only user payload in inline TreeView

### DIFF
--- a/data/components/frame-list.js
+++ b/data/components/frame-list.js
@@ -158,7 +158,9 @@ var FrameBubble = React.createFactory(React.createClass({
     if (!preview && frame.socketIo) {
       preview = TreeView({
         key: "preview-socketio",
-        data: {"Socket IO": frame.socketIo},
+        // We only show the data that is deemed interesting for the user in the
+        // inline previews, not the socketIO metadata
+        data: {"Socket IO": frame.socketIo.data},
         mode: "tiny"
       });
     }

--- a/data/components/frame-table.js
+++ b/data/components/frame-table.js
@@ -169,7 +169,9 @@ var FrameRow = React.createFactory(React.createClass({
     if (frame.socketIo) {
       payload = TreeView({
         key: "preview-socketio",
-        data: {"Socket IO": frame.socketIo},
+        // We only show the data that is deemed interesting for the user in the
+        // inline previews, not the socketIO metadata
+        data: {"Socket IO": frame.socketIo.data},
       });
     } else if (frame.sockJs) {
       payload = TreeView({


### PR DESCRIPTION
This adresses issue #53, and only shows the relevant data of a frame in the inline previews. As you suggested, this only includes socket.io so we can get a feel of this feature. 

The Socket.IO metadata is still visible in the sidebar, as I suggested.

Empty frames show up as `Socket IO  ""`, but I guess that should be adressed in #54. 
