### PR TITLE
Toggle Protocols

### DIFF
--- a/data/actions/config.js
+++ b/data/actions/config.js
@@ -1,0 +1,24 @@
+/* See license.txt for terms of usage */
+
+define(function(require, exports/*, module*/) {
+
+"use strict";
+
+const types = {
+  UPDATE_CONFIG: "UPDATE_CONFIG",
+}
+
+function updateConfig(key, newValue) {
+  var data = {
+    key,
+    newValue
+  };
+
+  return { type: types.UPDATE_CONFIG, data };
+}
+
+// Exports from this module
+exports.updateConfig = updateConfig;
+exports.types = types;
+});
+

--- a/data/components/frame-list.js
+++ b/data/components/frame-list.js
@@ -83,7 +83,7 @@ var FrameList = React.createClass({
         frame: frame,
         selection: this.props.selection,
         dispatch: this.props.dispatch,
-        config: this.props.dispatch
+        config: this.props.config
       }));
     }
 

--- a/data/components/frame-list.js
+++ b/data/components/frame-list.js
@@ -82,7 +82,8 @@ var FrameList = React.createClass({
         key: "frame-" + frame.id,
         frame: frame,
         selection: this.props.selection,
-        dispatch: this.props.dispatch
+        dispatch: this.props.dispatch,
+        config: this.props.dispatch
       }));
     }
 
@@ -156,7 +157,7 @@ var FrameBubble = React.createFactory(React.createClass({
     // Render inline frame preview. There is just one preview displayed
     var preview;
 
-    if (!preview && frame.socketIo) {
+    if (this.props.config.enableSocketIo !== false && frame.socketIo) {
       preview = TreeView({
         key: "preview-socketio",
         // We only show the data that is deemed interesting for the user in the
@@ -164,32 +165,29 @@ var FrameBubble = React.createFactory(React.createClass({
         data: {"Socket IO": frame.socketIo.data},
         mode: "tiny"
       });
-    }
-
-    if (!preview && frame.sockJs) {
+    } else if (this.props.config.enableSockJs !== false && frame.sockJs) {
       preview = TreeView({
         key: "preview-sockjs",
         data: {"SockJS": frame.sockJs},
         mode: "tiny"
       });
-    }
-
-    if (!preview && frame.json) {
+    } else if (this.props.config.enableJson !== false && frame.json) {
       preview = TreeView({
         key: "preview-json",
         data: {"JSON": frame.json},
         mode: "tiny"
       });
-    }
+    } else if (this.props.config.enableMqtt !== false && frame.mqtt) {
 
-    if (!preview && frame.mqtt) {
       var mqtt = frame.mqtt;
       op = "MQTT " + mqtt.cmd;
+
       if (mqtt.cmd === "publish") {
         payload = mqtt.topic;
       } else {
         payload = mqtt.messageId || mqtt.clientId || mqtt.returnCode;
       }
+
       preview = TreeView({
         key: "preview-mqtt",
         data: {"MQTT": mqtt},

--- a/data/components/frame-table.js
+++ b/data/components/frame-table.js
@@ -57,7 +57,8 @@ var FrameTable = React.createClass({
       key: frame.id,
       selection: this.props.selection,
       frame: frame,
-      dispatch: this.props.dispatch
+      dispatch: this.props.dispatch,
+      config: this.props.config
     }));
 
     // Render summary info
@@ -166,24 +167,24 @@ var FrameRow = React.createFactory(React.createClass({
     var payload;
 
     // Test support for inline previews.
-    if (frame.socketIo) {
+    if (this.props.config.enableSocketIo !== false && frame.socketIo) {
       payload = TreeView({
         key: "preview-socketio",
         // We only show the data that is deemed interesting for the user in the
         // inline previews, not the socketIO metadata
         data: {"Socket IO": frame.socketIo.data},
       });
-    } else if (frame.sockJs) {
+    } else if (this.props.config.enableSockJs !== false && frame.sockJs) {
       payload = TreeView({
         key: "preview-sockjs",
         data: {"SockJS": frame.sockJs},
       });
-    } else if (frame.json) {
+    } else if (this.props.config.enableJson !== false && frame.json) {
       payload = TreeView({
         key: "preview-json",
         data: {"JSON": frame.json},
       });
-    } else if (frame.mqtt) {
+    } else if (this.props.config.enableMqtt !== false && frame.mqtt) {
       payload = TreeView({
         key: "preview-mqtt",
         data: {"MQTT": frame.mqtt},

--- a/data/containers/app.js
+++ b/data/containers/app.js
@@ -101,6 +101,7 @@ var App = React.createClass({
 function mapStateToProps(state) {
   return {
     frames: state.frames,
+    config: state.config,
     selection: state.frames.selection,
     perspective: state.perspective
   };

--- a/data/reducers/config.js
+++ b/data/reducers/config.js
@@ -1,0 +1,26 @@
+/* See license.txt for terms of usage */
+
+define(function(require, exports/*, module*/) {
+
+"use strict";
+
+const { types } = require("../actions/config");
+
+const initialState = {};
+
+function config(state = initialState, action) {
+  switch (action.type) {
+  case types.UPDATE_CONFIG:
+    state[action.data.key] = action.data.newValue;
+
+    return state;
+
+  default:
+    return state;
+  }
+}
+
+// Exports from this module
+exports.config = config;
+});
+

--- a/data/reducers/index.js
+++ b/data/reducers/index.js
@@ -10,10 +10,12 @@ const { combineReducers } = require("redux");
 // WebSockets Monitor
 const { frames } = require("./frames");
 const { perspective } = require("./perspective");
+const { config } = require("./config");
 
 var rootReducer = combineReducers({
   frames,
-  perspective
+  perspective,
+  config
 });
 
 // Exports from this module

--- a/data/view.js
+++ b/data/view.js
@@ -59,10 +59,10 @@ var WebSocketsView = createView(PanelView,
     // Initialize the redux store with user preferences
     store = configureStore({
       config: {
-        enableSocketIo: Options.get('enableSocketIo'),
-        enableSockJs: Options.get('enableSockJs'),
-        enableJson: Options.get('enableJson'),
-        enableMqtt: Options.get('enableMqtt'),
+        enableSocketIo: Options.get("enableSocketIo"),
+        enableSockJs: Options.get("enableSockJs"),
+        enableJson: Options.get("enableJson"),
+        enableMqtt: Options.get("enableMqtt"),
       }
     });
 
@@ -167,18 +167,26 @@ var WebSocketsView = createView(PanelView,
   onPrefChanged: function(event) {
     var prefName = event.prefName;
 
-    if (prefName === "tabularView") {
+    switch (prefName) {
+      case "tabularView":
 
-      // Update the way how frames are displayed.
-      if (event.newValue) {
-        store.dispatch(showTableView());
-      } else {
-        store.dispatch(showListView());
-      }
-    } else {
+        // Update the way how frames are displayed.
+        if (event.newValue) {
+          store.dispatch(showTableView());
+        } else {
+          store.dispatch(showListView());
+        }
+        break;
+      case "enableSocketIo":
+      case "enableSockJs":
+      case "enableJson":
+      case "enableMqtt":
 
-      // Place generic config into config store
-      store.dispatch(updateConfig(prefName, event.newValue));
+        // Place protocol toggle prefs into config store
+        store.dispatch(updateConfig(prefName, event.newValue));
+        break;
+      default:
+        break;
     }
   }
 });

--- a/lib/wsm-panel.js
+++ b/lib/wsm-panel.js
@@ -228,6 +228,8 @@ const WsmPanel = Class(
   // Socket.IO Parser
 
   decodeSocketIoPacket: function(data) {
+    if (!prefs.enableSocketIo) return;
+
     let result;
     try {
       var decoder = new socketIoParser.Decoder();
@@ -251,6 +253,8 @@ const WsmPanel = Class(
    * Parse Sock.JS
    */
   decodeSockJsPacket: function(data) {
+    if (!prefs.enableSockJs) return;
+
     return sockJsParser.parse(data);
   },
 
@@ -258,6 +262,8 @@ const WsmPanel = Class(
    * Parse JSON
    */
   decodeJsonPacket: function(data) {
+    if (!prefs.enableJson) return;
+
     try {
       return JSON.parse(data);
     } catch (err) {
@@ -286,6 +292,8 @@ const WsmPanel = Class(
    * Parse MQTT using mqtt-packet parser
    */
   decodeMqttPacket: function(data) {
+    if (!prefs.enableMqtt) return;
+
     try {
       var parser = mqttParser();
       // View binary ACString input data as bytes

--- a/lib/wsm-panel.js
+++ b/lib/wsm-panel.js
@@ -228,7 +228,9 @@ const WsmPanel = Class(
   // Socket.IO Parser
 
   decodeSocketIoPacket: function(data) {
-    if (!prefs.enableSocketIo) return;
+    if (!prefs.enableSocketIo) {
+      return;
+    }
 
     let result;
     try {
@@ -253,7 +255,9 @@ const WsmPanel = Class(
    * Parse Sock.JS
    */
   decodeSockJsPacket: function(data) {
-    if (!prefs.enableSockJs) return;
+    if (!prefs.enableSockJs) {
+      return;
+    }
 
     return sockJsParser.parse(data);
   },
@@ -262,7 +266,9 @@ const WsmPanel = Class(
    * Parse JSON
    */
   decodeJsonPacket: function(data) {
-    if (!prefs.enableJson) return;
+    if (!prefs.enableJson) {
+      return;
+    }
 
     try {
       return JSON.parse(data);
@@ -292,20 +298,22 @@ const WsmPanel = Class(
    * Parse MQTT using mqtt-packet parser
    */
   decodeMqttPacket: function(data) {
-    if (!prefs.enableMqtt) return;
+    if (!prefs.enableMqtt) {
+      return;
+    }
 
     try {
       var parser = mqttParser();
       // View binary ACString input data as bytes
-      var buffer = new Buffer(data, 'binary');
+      var buffer = new Buffer(data, "binary");
       var result = null;
 
-      parser.on('packet', function(packet) {
+      parser.on("packet", function(packet) {
         // Assume there's only one MQTT packet in the Websocket frame
         result = packet;
       });
 
-      parser.on('error', function(packet) {
+      parser.on("error", function(packet) {
         // TODO: should we display an error somewhere?
       });
 
@@ -315,7 +323,7 @@ const WsmPanel = Class(
       if (result.cmd === "publish") {
         // Try to decode the payload binary buffer
         try {
-          result.payload = result.payload.toString('utf8');
+          result.payload = result.payload.toString("utf8");
           result.payload = JSON.parse(result.payload);
         } catch (err) {
         }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,35 @@
       "description": "Display sent and received frames in tabular format",
       "type": "bool",
       "value": true
+    },
+    {
+      "name": "enableSocketIo",
+      "title": "Socket.IO support",
+      "description": "Parse Socket.IO frames",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "name": "enableSockJs",
+      "title": "SockJS support",
+      "description": "Parse SockJS frames",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "name": "enableJson",
+      "title": "JSON support",
+      "description": "Parse JSON frames",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "name": "enableMqtt",
+      "title": "MQTT support",
+      "description": "Parse MQTT frames",
+      "type": "bool",
+      "value": true
     }
+
   ]
 }


### PR DESCRIPTION
# What

This PR adds a new feature - the ability to selectively enable or disable support for websocket protocols. This is added to the extension preferences window using the `simple-prefs` API.
# Why

There are a few downsides to having all protocols enabled at all times.
1. **Performance.** Having to try to parse every single frame into a plethora of protocols will kill perfomance in high-load situations. It is advantageous to be able to remove some or all protocols to allow for performant behaviour.
2. **Unused protocols.** Most of the time, you are only interested in the protocol you and your team are actually using. In my case I am using a JSON based system, yet subscribe frames, which look like `subscribe?...`, are parsed by the parser as MQTT, which is not what I expect it to do
# How

I added a new store and changed redux to be populated with the prefs at load. I also use the `onPrefChanged` hook to update the store on demand. Changing a setting is not retroactive, i.e. it will not change any already parsed frames, only future frames. I do not currently see this as an issue worth the complexity to fix.

![screen shot 2016-05-21 at 23 44 24](https://cloud.githubusercontent.com/assets/5845924/15450979/4dc32654-1fae-11e6-8105-dc2000a0fe87.png)
