### PR TITLE
Query String parsing

### DIFF
--- a/chrome/locale/en-US/websocket-monitor.properties
+++ b/chrome/locale/en-US/websocket-monitor.properties
@@ -47,6 +47,10 @@ websocketmonitor.WAMP=WAMP
 # panel that displays MQTT messages.
 websocketmonitor.MQTT=MQTT
 
+# LOCALIZATION NOTE (websocketmonitor.QueryString): A label used as a title for
+# side panel that displays messages formatted as a Query String (foo?bar=baz).
+websocketmonitor.QueryString=Query String
+
 # LOCALIZATION NOTE (websocketmonitor.option.tabularView): A label and tooltip
 # used for a toolbar button that allows switching the frame list to
 # Tabular view

--- a/data/components/frame-list.js
+++ b/data/components/frame-list.js
@@ -211,6 +211,13 @@ define(function (require, exports) {
           data: {"MQTT": mqtt},
           mode: "tiny"
         });
+      } else if (this.props.config.enableQueryString !== false
+                 && frame.queryString) {
+        preview = TreeView({
+          key: "preview-query",
+          data: {"Query String": frame.queryString},
+          mode: "tiny"
+        });
       }
 
       const label = (type == "send") ?

--- a/data/components/frame-table.js
+++ b/data/components/frame-table.js
@@ -208,6 +208,12 @@ define(function (require, exports) {
           key: "preview-mqtt",
           data: {"MQTT": frame.mqtt},
         });
+      } else if (this.props.config.enableQueryString !== false
+                 && frame.queryString) {
+        payload = TreeView({
+          key: "preview-query",
+          data: {"Query String": frame.queryString},
+        });
       } else {
         // Fall back to showing a string
         payload = Str.cropString(frame.data.payload, 50);

--- a/data/components/query-string-tab.js
+++ b/data/components/query-string-tab.js
@@ -1,0 +1,39 @@
+/* See license.txt for terms of usage */
+
+"use strict";
+
+define(function (require, exports) {
+  // Dependencies
+  const React = require("react");
+
+  // Firebug SDK
+  const { Reps } = require("reps/repository");
+  const { TreeView } = require("reps/tree-view");
+
+  // Shortcuts
+  const { DIV } = Reps.DOM;
+
+  /**
+   * Component responsible for rendering the Query String tab.
+   */
+  let QueryStringTab = React.createClass({
+  /** @lends QueryStringTab */
+
+    displayName: "QueryStringTab",
+
+    render: function () {
+      let selectedFrame = this.props.selection || {};
+      let data = selectedFrame.queryString;
+
+      return (
+        DIV({className: "details"},
+          TreeView({key: "QueryStringTabTree", data: data})
+        )
+      );
+    }
+  });
+
+  // Exports from this module
+  exports.QueryStringTab = QueryStringTab;
+});
+

--- a/data/components/sidebar.js
+++ b/data/components/sidebar.js
@@ -18,6 +18,7 @@ define(function (require, exports) {
   const { JSONTab } = createFactories(require("./json-tab"));
   const { WampTab } = createFactories(require("./wamp-tab"));
   const { MQTTTab } = createFactories(require("./mqtt-tab"));
+  const { QueryStringTab } = createFactories(require("./query-string-tab"));
 
   /**
    * @template This template represents a list of packets displayed
@@ -90,6 +91,14 @@ define(function (require, exports) {
           TabPanel({className: "mqtt", key: "mqtt",
             title: Locale.$STR("websocketmonitor.MQTT")},
             MQTTTab(this.props)
+        ));
+      }
+
+      if (selectedFrame && selectedFrame.queryString) {
+        tabs.push(
+          TabPanel({className: "mqtt", key: "queryString",
+            title: Locale.$STR("websocketmonitor.QueryString")},
+            QueryStringTab(this.props)
         ));
       }
 

--- a/data/view.js
+++ b/data/view.js
@@ -61,6 +61,7 @@ define(function (require) {
             enableSockJs: Options.get("enableSockJs"),
             enableJson: Options.get("enableJson"),
             enableMqtt: Options.get("enableMqtt"),
+            enableQueryString: Options.get("enableQueryString"),
           }
         });
 

--- a/lib/wsm-panel.js
+++ b/lib/wsm-panel.js
@@ -223,6 +223,7 @@ const WsmPanel = Class(
     data.wamp = this.decodeWampPacket(payload);
     data.json = this.decodeJsonPacket(payload);
     data.mqtt = this.decodeMqttPacket(payload);
+    data.queryString = this.decodeQueryString(payload);
   },
 
   // Socket.IO Parser
@@ -333,6 +334,36 @@ const WsmPanel = Class(
     } catch (err) {
       return;
     }
+  },
+
+  /**
+   * Parse query strings
+   */
+  decodeQueryString: function(data) {
+    if (!prefs.enableQueryString) {
+      return;
+    }
+
+    // Check if the data matches foo?bar
+    if (!/\w+\?.+/.test(data)) {
+      return;
+    }
+
+    const result = {};
+
+    var vars = data.substr(data.indexOf('?') + 1).split('&');
+    vars.forEach(function(item) {
+      var pair = item.split('=');
+
+      // ?foo&bar&baz is valid
+      if (pair.length === 2) {
+        result[pair[0]] = decodeURIComponent(pair[1]);
+      } else {
+        result[pair[0]] = undefined;
+      }
+    });
+
+    return result;
   },
 
   // NetMonitor Overlay

--- a/package.json
+++ b/package.json
@@ -82,6 +82,13 @@
       "description": "Parse MQTT frames",
       "type": "bool",
       "value": true
+    },
+    {
+      "name": "enableQueryString",
+      "title": "Query string support",
+      "description": "Parse query string frames (frames that look like foo&bar=baz)",
+      "type": "bool",
+      "value": true
     }
   ]
 }


### PR DESCRIPTION
# What

This PR adds a new feature to websocket-monitor, making it possible to display a query string as a `TreeView`. See the screenshot below for an example.
# Why

Because I was bored :smile: 

No really, at work we use query strings at work to configure our serverside components to send a custom response. As I have mentioned before, these are strings in the form of `subscribe?...`. This feature will make it a lot easier to read these strings. It also urldecodes the values of the fields for convenience.

![screenshot_20160711_224120](https://cloud.githubusercontent.com/assets/5845924/16745991/9f46ecea-47b8-11e6-980c-b8a445cce664.png)
