### PR TITLE
Adapt to new Netmonitor panel architecture

### DIFF
--- a/chrome/content/network-content-script.js
+++ b/chrome/content/network-content-script.js
@@ -17,47 +17,55 @@
  * The icons serves also as a link to the 'Web Socket'
  * panel.
  */
-window.on(EVENTS.RECEIVED_REQUEST_HEADERS, (_, from) => {
-  let item = NetMonitorView.RequestsMenu.getItemByValue(from);
-  if (!isWsUpgradeRequest(item)) {
-    return;
-  }
-
-  // Append WebSocket icon in the UI
-  let hbox = item._target;
-
-  let method = hbox.querySelector(".requests-menu-method");
-  method.classList.add("websocket");
-
-  // Fx 45 changed the DOM layout in the network panel and also
-  // the WS icon isn't overlapping the original status icon now.
-  // But, we need a little indentation for pre Fx45.
-  let statusIconNode = hbox.querySelector(".requests-menu-status-icon");
-  if (!statusIconNode) {
-    // We are in pre Fx45 world, use a little indentation.
-    method.classList.add("websocket-indent");
-  }
-
-  // Register click handler and emit an event that is handled
-  // in the 'WsmNetMonitorOverlay' overlay.
-  // xxxHonza: this registers multiple listeners on the window
-  // object that are all executed when the user clicks on the
-  // WS icon. FIXME
-  window.addEventListener("click", event => {
-    if (event.target.classList.contains("websocket")) {
-      navigateToWebSocketPanel(from);
+if (EVENTS.REQUEST_ITEM_CLICKED) {
+  window.on(EVENTS.REQUEST_ITEM_CLICKED, (_, e, item) => {
+    if (e.target.closest(".request-list-item.websocket .requests-menu-method")) {
+      navigateToWebSocketPanel(item.id);
     }
   });
-
-  // Do not open the Network panel side-bar if the user clicks
-  // on the WS icon.
-  window.addEventListener("mousedown", event => {
-    if (event.target.classList.contains("websocket")) {
-      event.stopPropagation();
-      event.preventDefault();
+} else {
+  window.on(EVENTS.RECEIVED_REQUEST_HEADERS, (_, from) => {
+    let item = NetMonitorView.RequestsMenu.getItemByValue(from);
+    if (!isWsUpgradeRequest(item)) {
+      return;
     }
-  }, true);
-});
+
+    // Append WebSocket icon in the UI
+    let hbox = item._target;
+
+    let method = hbox.querySelector(".requests-menu-method");
+    method.classList.add("websocket");
+
+    // Fx 45 changed the DOM layout in the network panel and also
+    // the WS icon isn't overlapping the original status icon now.
+    // But, we need a little indentation for pre Fx45.
+    let statusIconNode = hbox.querySelector(".requests-menu-status-icon");
+    if (!statusIconNode) {
+      // We are in pre Fx45 world, use a little indentation.
+      method.classList.add("websocket-indent");
+    }
+
+    // Register click handler and emit an event that is handled
+    // in the 'WsmNetMonitorOverlay' overlay.
+    // xxxHonza: this registers multiple listeners on the window
+    // object that are all executed when the user clicks on the
+    // WS icon. FIXME
+    window.addEventListener("click", event => {
+      if (event.target.classList.contains("websocket")) {
+        navigateToWebSocketPanel(from);
+      }
+    });
+
+    // Do not open the Network panel side-bar if the user clicks
+    // on the WS icon.
+    window.addEventListener("mousedown", event => {
+      if (event.target.classList.contains("websocket")) {
+        event.stopPropagation();
+        event.preventDefault();
+      }
+    }, true);
+  });
+}
 
 /**
  * Handle Response body displayed event.

--- a/chrome/skin/classic/netmonitor.css
+++ b/chrome/skin/classic/netmonitor.css
@@ -4,10 +4,11 @@
 /* Network Panel */
 
 /* Web Socket Icon */
-.requests-menu-method.websocket {
+.requests-menu-method.websocket,
+.request-list-item.websocket .requests-menu-method {
   background-image: url("./tool-websockets.svg");
   background-repeat: no-repeat;
-  background-position: 0 1px;
+  background-position: left center;
 }
 
 /* Make sure the icon works in all themes */


### PR DESCRIPTION
This PR is a complement to Netmonitor changes in [bug 1316834](https://bugzilla.mozilla.org/show_bug.cgi?id=1316834).

It checks if the `EVENTS.REQUEST_ITEM_CLICKED` event is available and if it is, adds a listener. If it's not, the legacy code is executed.

The CSS change adds the WebSocket icon to a "method" column with the right CSS class, and also improves the icon alignment.
